### PR TITLE
✔ Correct option assignment for rejectUnauthorized

### DIFF
--- a/sendmail.js
+++ b/sendmail.js
@@ -24,7 +24,7 @@ module.exports = function (options) {
   const devHost = options.devHost || 'localhost';
   const smtpPort = options.smtpPort || 25 
   const smtpHost = options.smtpHost || -1
-  const rejectUnauthorized = options.rejectUnauthorized || true;
+  const rejectUnauthorized = options.rejectUnauthorized;
   
   /*
    *   邮件服务返回代码含义 Mail service return code Meaning


### PR DESCRIPTION
Removed the unnecessary default value assignment of the `rejectUnauthorized` option.

Due to the way the default value was assigned, any attempt to set `rejectUnauthorized` to `false` would just result in the default value being used instead. Now we leave the defaults up to Node, which is probably the better approach. 👍
(`false || true` === `true`)